### PR TITLE
ci: opt in to the shared Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["github>sinemacula/coding-standards"]
+}


### PR DESCRIPTION
Opts this repo into the shared Renovate config: adds a `renovate.json` extending `github>sinemacula/coding-standards` so its coding-standards dependency stays current automatically.