### PR TITLE
style: maximize docblock line wrapping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
             "@php vendor/bin/paratest --coverage-clover=clover.xml"
         ],
         "test:mutation": [
-            "@php -d memory_limit=-1 vendor/bin/infection --configuration=infection.json5 --test-framework-options=\"--do-not-fail-on-warning --do-not-fail-on-phpunit-warning\" --only-covering-test-cases --threads=max --git-diff-lines --git-diff-base=origin/master --map-source-class-to-test --min-msi=90 --min-covered-msi=90"
+            "@php -d memory_limit=-1 vendor/bin/infection --configuration=infection.json5 --test-framework-options=\"--do-not-fail-on-warning --do-not-fail-on-phpunit-warning\" --only-covering-test-cases --threads=max --git-diff-lines --git-diff-base=origin/master --map-source-class-to-test --min-msi=90 --min-covered-msi=90 --ignore-msi-with-no-mutations"
         ],
         "test:mutation:full": [
             "@php -d memory_limit=-1 vendor/bin/infection --configuration=infection.full.json5 --test-framework-options=\"--do-not-fail-on-warning --do-not-fail-on-phpunit-warning\" --only-covering-test-cases --threads=max"

--- a/src/Concerns/BootsConcerns.php
+++ b/src/Concerns/BootsConcerns.php
@@ -9,9 +9,9 @@ namespace SineMacula\Repositories\Concerns;
  * repository.
  *
  * Concerns such as Cacheable need boot-time setup but cannot override boot()
- * without colliding with a subclass boot() override, so the repository
- * invokes their dedicated boot hooks after boot() has run instead. This lets
- * a single repository safely use more than one bootable concern.
+ * without colliding with a subclass boot() override, so the repository invokes
+ * their dedicated boot hooks after boot() has run instead. This lets a single
+ * repository safely use more than one bootable concern.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/Concerns/CacheConfiguration.php
+++ b/src/Concerns/CacheConfiguration.php
@@ -8,12 +8,12 @@ use Illuminate\Support\Facades\Config;
 
 /**
  * Resolves the tuning configuration for a cacheable repository from its
- * overridable property values and the package configuration, in that
- * precedence order.
+ * overridable property values and the package configuration, in that precedence
+ * order.
  *
  * Constructed once per repository instance in bootCacheable(), from the
- * already-extracted overridable property values, so CacheStoreOptions is
- * always built from named values rather than a positional parameter list.
+ * already-extracted overridable property values, so CacheStoreOptions is always
+ * built from named values rather than a positional parameter list.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -51,8 +51,8 @@ final class CacheConfiguration
     ) {}
 
     /**
-     * Resolve the cache configuration from a repository's overridable
-     * property values and the package configuration.
+     * Resolve the cache configuration from a repository's overridable property
+     * values and the package configuration.
      *
      * @param  array<string, bool|int|string|null>  $overrides
      * @param  string  $table

--- a/src/Concerns/CacheStore.php
+++ b/src/Concerns/CacheStore.php
@@ -123,11 +123,10 @@ final class CacheStore implements CacheInvalidator
      * Get the raw cached entry for the given query fingerprint in a single
      * round trip.
      *
-     * The negative-cache marker is returned as-is, so a caller can
-     * distinguish an absent entry (null), a negative hit (CacheMiss), and a
-     * cached value without a separate has() check - and without the window
-     * where an entry expiring between the two calls masquerades as a negative
-     * hit.
+     * The negative-cache marker is returned as-is, so a caller can distinguish
+     * an absent entry (null), a negative hit (CacheMiss), and a cached value
+     * without a separate has() check - and without the window where an entry
+     * expiring between the two calls masquerades as a negative hit.
      *
      * @param  string  $hash
      * @return mixed
@@ -138,8 +137,7 @@ final class CacheStore implements CacheInvalidator
     }
 
     /**
-     * Store the given value for a query fingerprint, subject to the size
-     * guard.
+     * Store the given value for a query fingerprint, subject to the size guard.
      *
      * @param  string  $hash
      * @param  mixed  $value
@@ -220,15 +218,15 @@ final class CacheStore implements CacheInvalidator
     }
 
     /**
-     * Atomically increment a table's generational version, seeding the key
-     * when the store cannot increment a missing entry.
+     * Atomically increment a table's generational version, seeding the key when
+     * the store cannot increment a missing entry.
      *
      * Some stores (e.g. the database driver) return false instead of creating
-     * the key on increment, which would silently reduce every version bump to
-     * a no-op; add() seeds the key atomically so concurrent writers converge
-     * on a single counter before retrying the increment. Returns null when the
-     * increment still fails after the seed retry - a store outage rather than
-     * a missing key - so the caller can surface the failure instead of masking
+     * the key on increment, which would silently reduce every version bump to a
+     * no-op; add() seeds the key atomically so concurrent writers converge on a
+     * single counter before retrying the increment. Returns null when the
+     * increment still fails after the seed retry - a store outage rather than a
+     * missing key - so the caller can surface the failure instead of masking
      * it.
      *
      * @param  \Illuminate\Contracts\Cache\Repository  $store
@@ -327,9 +325,9 @@ final class CacheStore implements CacheInvalidator
      * Bump the table's generational version, orphaning every existing per-query
      * key for the table in a single atomic write.
      *
-     * Falls back to a local, unpersisted bump when the store cannot persist
-     * the increment, so this instance still stops serving pre-flush entries;
-     * the failure is logged since other processes never observe it.
+     * Falls back to a local, unpersisted bump when the store cannot persist the
+     * increment, so this instance still stops serving pre-flush entries; the
+     * failure is logged since other processes never observe it.
      *
      * @return void
      */

--- a/src/Concerns/Cacheable.php
+++ b/src/Concerns/Cacheable.php
@@ -121,8 +121,8 @@ trait Cacheable
      * Boot the cacheable concern.
      *
      * Invoked by Repository::bootConcerns() rather than overriding boot()
-     * directly, so the concern can coexist with other bootable concerns
-     * without a fatal trait collision.
+     * directly, so the concern can coexist with other bootable concerns without
+     * a fatal trait collision.
      *
      * @return void
      *
@@ -279,9 +279,9 @@ trait Cacheable
      * Consumes the one-shot criteria flags exactly as a normal query pipeline
      * would, so a skipCriteria()/useCriteria() intended for this read cannot
      * leak onto a later, unrelated query. The flags are only consumed on the
-     * branches that actually serve the snapshot: an unsupported find() id
-     * falls back to the real query pipeline instead, which must see the
-     * flags untouched so parent::__call() can consume them itself.
+     * branches that actually serve the snapshot: an unsupported find() id falls
+     * back to the real query pipeline instead, which must see the flags
+     * untouched so parent::__call() can consume them itself.
      *
      * @param  string  $method
      * @param  array<int, mixed>  $arguments
@@ -332,13 +332,13 @@ trait Cacheable
     }
 
     /**
-     * Determine whether repository-level query composition is pending, in
-     * which case a reference read must execute a real query rather than serve
-     * the unfiltered whole-table snapshot.
+     * Determine whether repository-level query composition is pending, in which
+     * case a reference read must execute a real query rather than serve the
+     * unfiltered whole-table snapshot.
      *
      * Scopes are Cacheable's own concern; the criteria precedence itself is
-     * owned by ManagesCriteria::hasPendingComposition() so applyCriteria()
-     * and this check can never silently diverge.
+     * owned by ManagesCriteria::hasPendingComposition() so applyCriteria() and
+     * this check can never silently diverge.
      *
      * @return bool
      */

--- a/src/Concerns/ManagesCriteria.php
+++ b/src/Concerns/ManagesCriteria.php
@@ -262,14 +262,14 @@ trait ManagesCriteria
     }
 
     /**
-     * Determine whether the registered criteria would change the next query
-     * if applyCriteria() ran now.
+     * Determine whether the registered criteria would change the next query if
+     * applyCriteria() ran now.
      *
      * Mirrors applyCriteria()'s own precedence exactly, without consuming any
-     * of the one-shot flags, so a caller can decide how to serve the next
-     * read before committing to executing it. This is the single owner of
-     * that precedence; collaborators must delegate here rather than
-     * re-deriving it from the underlying criteria state.
+     * of the one-shot flags, so a caller can decide how to serve the next read
+     * before committing to executing it. This is the single owner of that
+     * precedence; collaborators must delegate here rather than re-deriving it
+     * from the underlying criteria state.
      *
      * @return bool
      */

--- a/src/Concerns/QueryFingerprint.php
+++ b/src/Concerns/QueryFingerprint.php
@@ -16,10 +16,10 @@ use SineMacula\Repositories\Exceptions\UnfingerprintableQueryException;
  * The fingerprint folds in the connection identity, the model class, the
  * compiled SQL, the normalised bindings, the read verb and its arguments, and
  * the eager loads - including each constraint closure's definition site,
- * captures, and bound instance state - since all of these are invisible to
- * the compiled base SQL yet still distinguish one read from another. Values
- * with no stable representation (e.g. closures passed as verb arguments)
- * cannot be fingerprinted and cause fingerprinting to fail.
+ * captures, and bound instance state - since all of these are invisible to the
+ * compiled base SQL yet still distinguish one read from another. Values with no
+ * stable representation (e.g. closures passed as verb arguments) cannot be
+ * fingerprinted and cause fingerprinting to fail.
  *
  * The digest is produced with xxh128: a fast, non-cryptographic 128-bit hash.
  * Accidental collisions are negligible at this width, but it offers no
@@ -140,13 +140,13 @@ final class QueryFingerprint
      * Unconstrained eager loads compile to an empty closure defined inside the
      * framework, so they share one stable identity; user-supplied constraints
      * are identified by where they are defined, what they capture, and the
-     * state of a bound $this, keeping the fingerprint stable across requests
-     * on the same codebase while still distinguishing constraints that differ
-     * only by that instance state.
+     * state of a bound $this, keeping the fingerprint stable across requests on
+     * the same codebase while still distinguishing constraints that differ only
+     * by that instance state.
      *
-     * The result is memoised per closure instance for the life of the
-     * request; the fingerprint reflects capture state at first evaluation of
-     * that closure instance.
+     * The result is memoised per closure instance for the life of the request;
+     * the fingerprint reflects capture state at first evaluation of that
+     * closure instance.
      *
      * @param  \Closure  $constraint
      *
@@ -195,8 +195,8 @@ final class QueryFingerprint
      *
      * Atomic-release deployments unpack each release into a fresh, timestamped
      * directory, so the absolute path to an unchanged file differs between
-     * deploys; stripping the application base path keeps the fingerprint
-     * stable while still distinguishing files that differ beyond that prefix.
+     * deploys; stripping the application base path keeps the fingerprint stable
+     * while still distinguishing files that differ beyond that prefix.
      *
      * @param  false|string  $path
      * @return string

--- a/src/Contracts/RepositoryCriteriaInterface.php
+++ b/src/Contracts/RepositoryCriteriaInterface.php
@@ -8,8 +8,8 @@ use Illuminate\Support\Collection;
 
 /**
  * Declares the criteria lifecycle contract a repository must expose: register
- * criteria (persistently or for the next query only), remove them, inspect
- * what is currently active, and toggle their application at runtime.
+ * criteria (persistently or for the next query only), remove them, inspect what
+ * is currently active, and toggle their application at runtime.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/src/RepositoryServiceProvider.php
+++ b/src/RepositoryServiceProvider.php
@@ -10,8 +10,8 @@ use Illuminate\Support\ServiceProvider;
  * Repository service provider.
  *
  * Merges the package configuration and offers it for publishing. The provider
- * registers no bindings of its own: repositories are resolved directly from
- * the container and the cache collaborators are constructed at boot by the
+ * registers no bindings of its own: repositories are resolved directly from the
+ * container and the cache collaborators are constructed at boot by the
  * Cacheable concern.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>

--- a/tests/Integration/Concerns/CacheConfigurationTest.php
+++ b/tests/Integration/Concerns/CacheConfigurationTest.php
@@ -146,8 +146,7 @@ final class CacheConfigurationTest extends IntegrationTestCase
     /**
      * Test that a repository-level override takes exact precedence over the
      * packaged default even though the default is itself a non-null value,
-     * proving the override is read first rather than merely coalesced with
-     * it.
+     * proving the override is read first rather than merely coalesced with it.
      *
      * @return void
      */
@@ -161,8 +160,8 @@ final class CacheConfigurationTest extends IntegrationTestCase
 
     /**
      * Test that the packaged byte-size default is applied at its exact
-     * boundary, so a result serializing to precisely the ceiling is allowed
-     * and one byte over is rejected.
+     * boundary, so a result serializing to precisely the ceiling is allowed and
+     * one byte over is rejected.
      *
      * @return void
      */
@@ -193,8 +192,8 @@ final class CacheConfigurationTest extends IntegrationTestCase
     }
 
     /**
-     * Build a string whose serialized representation is exactly the given
-     * byte length.
+     * Build a string whose serialized representation is exactly the given byte
+     * length.
      *
      * @param  int  $bytes
      * @return string

--- a/tests/Integration/Concerns/CacheStoreTest.php
+++ b/tests/Integration/Concerns/CacheStoreTest.php
@@ -560,10 +560,10 @@ final class CacheStoreTest extends IntegrationTestCase
     }
 
     /**
-     * Test that a persistently failing version increment (both the initial
-     * call and the post-seed retry fail, as on a genuine store outage) is
-     * logged at error level from the instance flush path, so a process other
-     * than the writer can discover that its invalidation was never persisted.
+     * Test that a persistently failing version increment (both the initial call
+     * and the post-seed retry fail, as on a genuine store outage) is logged at
+     * error level from the instance flush path, so a process other than the
+     * writer can discover that its invalidation was never persisted.
      *
      * @return void
      */
@@ -613,8 +613,8 @@ final class CacheStoreTest extends IntegrationTestCase
     }
 
     /**
-     * Test that fetch() distinguishes an absent entry, a negative-cache
-     * marker, and a cached value in a single lookup.
+     * Test that fetch() distinguishes an absent entry, a negative-cache marker,
+     * and a cached value in a single lookup.
      *
      * @return void
      */

--- a/tests/Integration/Concerns/CacheableTest.php
+++ b/tests/Integration/Concerns/CacheableTest.php
@@ -533,8 +533,8 @@ final class CacheableTest extends IntegrationTestCase
 
     /**
      * Test that a cached read which throws leaves no dirty builder or scope
-     * state behind, so the next cached read composes from a clean slate
-     * instead of inheriting the failed call's constraints.
+     * state behind, so the next cached read composes from a clean slate instead
+     * of inheriting the failed call's constraints.
      *
      * @return void
      */
@@ -585,8 +585,8 @@ final class CacheableTest extends IntegrationTestCase
 
     /**
      * Test that a scalar value() result is cached regardless of the size
-     * guard's row ceiling, proving a non-collection, non-model result counts
-     * as zero rows.
+     * guard's row ceiling, proving a non-collection, non-model result counts as
+     * zero rows.
      *
      * @return void
      */
@@ -608,10 +608,9 @@ final class CacheableTest extends IntegrationTestCase
     }
 
     /**
-     * Test that a reference-mode find() with a mixed-type array of ids
-     * resolves only the entries whose id is a supported int or string shape,
-     * silently dropping any other value rather than including or crashing on
-     * it.
+     * Test that a reference-mode find() with a mixed-type array of ids resolves
+     * only the entries whose id is a supported int or string shape, silently
+     * dropping any other value rather than including or crashing on it.
      *
      * @return void
      */
@@ -870,9 +869,9 @@ final class CacheableTest extends IntegrationTestCase
 
     /**
      * Test that a one-shot skipCriteria() is still honoured when a
-     * reference-mode find() falls back to a real query because the id
-     * argument is an unsupported shape, and that the flag does not leak onto
-     * a later, unrelated read.
+     * reference-mode find() falls back to a real query because the id argument
+     * is an unsupported shape, and that the flag does not leak onto a later,
+     * unrelated read.
      *
      * @return void
      */
@@ -900,8 +899,8 @@ final class CacheableTest extends IntegrationTestCase
     /**
      * Test that a one-shot useCriteria() still forces disabled persistent
      * criteria on when a reference-mode find() falls back to a real query
-     * because the id argument is an unsupported shape, and that the force
-     * does not leak onto a later, unrelated read.
+     * because the id argument is an unsupported shape, and that the force does
+     * not leak onto a later, unrelated read.
      *
      * @return void
      */
@@ -928,8 +927,8 @@ final class CacheableTest extends IntegrationTestCase
     }
 
     /**
-     * Test that a read whose reference-mode id argument is an unsupported
-     * shape logs the real-query fallback at debug level.
+     * Test that a read whose reference-mode id argument is an unsupported shape
+     * logs the real-query fallback at debug level.
      *
      * @return void
      */
@@ -1045,9 +1044,9 @@ final class CacheableTest extends IntegrationTestCase
     }
 
     /**
-     * Test that a repository's reference-mode TTL override is honoured, so
-     * the snapshot expires at the configured duration rather than the
-     * packaged default.
+     * Test that a repository's reference-mode TTL override is honoured, so the
+     * snapshot expires at the configured duration rather than the packaged
+     * default.
      *
      * @return void
      */
@@ -1156,8 +1155,8 @@ final class CacheableTest extends IntegrationTestCase
     /**
      * Test that the reference-mode snapshot cache key is composed from the
      * exact prefix, connection name, and database name in that order, so
-     * dropping or reordering any component of that composition is observable
-     * as a missing key.
+     * dropping or reordering any component of that composition is observable as
+     * a missing key.
      *
      * @return void
      */
@@ -1211,8 +1210,8 @@ final class CacheableTest extends IntegrationTestCase
     }
 
     /**
-     * Test that rowCount() returns the exact row count for each result shape:
-     * a collection's item count, a single model as exactly one row, and every
+     * Test that rowCount() returns the exact row count for each result shape: a
+     * collection's item count, a single model as exactly one row, and every
      * other value (including null) as zero rows.
      *
      * @return void

--- a/tests/Integration/Concerns/QueryFingerprintTest.php
+++ b/tests/Integration/Concerns/QueryFingerprintTest.php
@@ -338,12 +338,12 @@ final class QueryFingerprintTest extends IntegrationTestCase
     }
 
     /**
-     * Test that a closure's definition-site file path is normalised relative
-     * to the application base path, so an unchanged file fingerprints
-     * identically across releases regardless of how the base path is
-     * written, while a base path that does not actually prefix the
-     * definition site - or the absence of a bound application altogether -
-     * leaves the path, and therefore the fingerprint, unchanged.
+     * Test that a closure's definition-site file path is normalised relative to
+     * the application base path, so an unchanged file fingerprints identically
+     * across releases regardless of how the base path is written, while a base
+     * path that does not actually prefix the definition site - or the absence
+     * of a bound application altogether - leaves the path, and therefore the
+     * fingerprint, unchanged.
      *
      * @param  \Illuminate\Container\Container  $first
      * @param  \Illuminate\Container\Container  $second
@@ -376,8 +376,8 @@ final class QueryFingerprintTest extends IntegrationTestCase
 
     /**
      * Test that a closure passed as a verb argument cannot be fingerprinted,
-     * since two distinct closures have no stable representation and must
-     * never collide on one cache key.
+     * since two distinct closures have no stable representation and must never
+     * collide on one cache key.
      *
      * @return void
      */
@@ -425,8 +425,8 @@ final class QueryFingerprintTest extends IntegrationTestCase
 
     /**
      * Build a tag query whose only eager load is the aligned constraint
-     * fixture, registered directly so the fingerprinted closure is the
-     * fixture itself rather than a framework-generated wrapper around it.
+     * fixture, registered directly so the fingerprinted closure is the fixture
+     * itself rather than a framework-generated wrapper around it.
      *
      * @return \Illuminate\Contracts\Database\Eloquent\Builder
      */

--- a/tests/Integration/Concerns/ReferenceCacheTest.php
+++ b/tests/Integration/Concerns/ReferenceCacheTest.php
@@ -122,8 +122,8 @@ final class ReferenceCacheTest extends IntegrationTestCase
     /**
      * Test that a fresh instance sharing the same backing store remembers an
      * already-cached snapshot without re-querying the database, proving the
-     * cache-hit path memoises and indexes the stored snapshot rather than
-     * only the freshly-loaded one.
+     * cache-hit path memoises and indexes the stored snapshot rather than only
+     * the freshly-loaded one.
      *
      * @return void
      */
@@ -273,11 +273,11 @@ final class ReferenceCacheTest extends IntegrationTestCase
     }
 
     /**
-     * Test that two reference caches whose table identifier is qualified with
-     * a distinct connection identity (as bootCacheable() composes it) never
-     * share a snapshot, even though the underlying table name is the same -
-     * closing the cross-connection disclosure a bare table-name key would
-     * otherwise allow.
+     * Test that two reference caches whose table identifier is qualified with a
+     * distinct connection identity (as bootCacheable() composes it) never share
+     * a snapshot, even though the underlying table name is the same - closing
+     * the cross-connection disclosure a bare table-name key would otherwise
+     * allow.
      *
      * @return void
      */

--- a/tests/Integration/CriteriaFlagStateTest.php
+++ b/tests/Integration/CriteriaFlagStateTest.php
@@ -88,8 +88,8 @@ final class CriteriaFlagStateTest extends IntegrationTestCase
     /**
      * State 3: D=false, S=false, F=true, T=empty.
      *
-     * Persistent criteria applied. $forceUseCriteria is redundant when
-     * criteria are not disabled.
+     * Persistent criteria applied. $forceUseCriteria is redundant when criteria
+     * are not disabled.
      *
      * @return void
      */
@@ -107,8 +107,8 @@ final class CriteriaFlagStateTest extends IntegrationTestCase
     /**
      * State 4: D=false, S=false, F=true, T=present.
      *
-     * Both persistent and transient criteria applied. This is the typical
-     * state after calling withCriteria().
+     * Both persistent and transient criteria applied. This is the typical state
+     * after calling withCriteria().
      *
      * @return void
      */

--- a/tests/Integration/PerQueryCacheInvalidationTest.php
+++ b/tests/Integration/PerQueryCacheInvalidationTest.php
@@ -17,8 +17,8 @@ use Tests\Support\Repositories\DatabaseStoreTagRepository;
 use Tests\Support\Repositories\FileStoreTagRepository;
 
 /**
- * Integration tests for per-query repository cache invalidation on write
- * verbs, against a real database.
+ * Integration tests for per-query repository cache invalidation on write verbs,
+ * against a real database.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.
@@ -206,8 +206,8 @@ final class PerQueryCacheInvalidationTest extends IntegrationTestCase
     }
 
     /**
-     * Test that forceCreateQuietly invalidates the cache when it inserts a
-     * new row.
+     * Test that forceCreateQuietly invalidates the cache when it inserts a new
+     * row.
      *
      * @return void
      */

--- a/tests/Integration/PerQueryCacheTest.php
+++ b/tests/Integration/PerQueryCacheTest.php
@@ -240,8 +240,8 @@ final class PerQueryCacheTest extends IntegrationTestCase
     }
 
     /**
-     * Test that reads whose arguments contain closures execute uncached, so
-     * two distinct closures can never be served each other's results.
+     * Test that reads whose arguments contain closures execute uncached, so two
+     * distinct closures can never be served each other's results.
      *
      * @return void
      */
@@ -293,8 +293,8 @@ final class PerQueryCacheTest extends IntegrationTestCase
     }
 
     /**
-     * Test that reference mode executes a real filtered query when criteria
-     * are active instead of serving the unfiltered snapshot.
+     * Test that reference mode executes a real filtered query when criteria are
+     * active instead of serving the unfiltered snapshot.
      *
      * @return void
      */

--- a/tests/Integration/RepositoryCriteriaIntegrationTest.php
+++ b/tests/Integration/RepositoryCriteriaIntegrationTest.php
@@ -15,8 +15,8 @@ use Tests\Support\Criteria\NamedUsersCriterion;
 use Tests\Support\Repositories\TestUserRepository;
 
 /**
- * Integration tests for repository persistent, transient, and one-shot
- * criteria management.
+ * Integration tests for repository persistent, transient, and one-shot criteria
+ * management.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Integration/RepositoryIntegrationTest.php
+++ b/tests/Integration/RepositoryIntegrationTest.php
@@ -265,8 +265,8 @@ final class RepositoryIntegrationTest extends IntegrationTestCase
 
     /**
      * Verify a secondary model re-resolution failure during failure cleanup is
-     * logged and swallowed, leaving the model null while the original
-     * exception still propagates to the caller.
+     * logged and swallowed, leaving the model null while the original exception
+     * still propagates to the caller.
      *
      * @return void
      */

--- a/tests/Support/Closures/BoundConstraint.php
+++ b/tests/Support/Closures/BoundConstraint.php
@@ -8,8 +8,8 @@ use Illuminate\Contracts\Database\Eloquent\Builder;
 
 /**
  * Fixture producing an eager-load constraint closure bound to an instance, so
- * tests can prove that two closures from the same definition site but
- * differing bound-instance state never share a fingerprint.
+ * tests can prove that two closures from the same definition site but differing
+ * bound-instance state never share a fingerprint.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Support/Criteria/ActiveUsersCriterion.php
+++ b/tests/Support/Criteria/ActiveUsersCriterion.php
@@ -23,8 +23,8 @@ final class ActiveUsersCriterion implements CriteriaInterface
     /**
      * Apply the active-user condition.
      *
-     * The repository guarantees Builder input; the assertion narrows the
-     * type for static analysis only.
+     * The repository guarantees Builder input; the assertion narrows the type
+     * for static analysis only.
      *
      * @param  \Illuminate\Contracts\Database\Eloquent\Builder|\Illuminate\Database\Eloquent\Model  $model
      * @return \Illuminate\Contracts\Database\Eloquent\Builder

--- a/tests/Support/Criteria/NamedTagsCriterion.php
+++ b/tests/Support/Criteria/NamedTagsCriterion.php
@@ -35,8 +35,8 @@ final class NamedTagsCriterion implements CriteriaInterface
     /**
      * Apply the name condition.
      *
-     * The repository guarantees Builder input; the assertion narrows the
-     * type for static analysis only.
+     * The repository guarantees Builder input; the assertion narrows the type
+     * for static analysis only.
      *
      * @param  \Illuminate\Contracts\Database\Eloquent\Builder|\Tests\Support\Models\Tag  $model
      * @return \Illuminate\Contracts\Database\Eloquent\Builder

--- a/tests/Support/Criteria/NamedUsersCriterion.php
+++ b/tests/Support/Criteria/NamedUsersCriterion.php
@@ -34,8 +34,8 @@ final class NamedUsersCriterion implements CriteriaInterface
     /**
      * Apply the name condition.
      *
-     * The repository guarantees Builder input; the assertion narrows the
-     * type for static analysis only.
+     * The repository guarantees Builder input; the assertion narrows the type
+     * for static analysis only.
      *
      * @param  \Illuminate\Contracts\Database\Eloquent\Builder|\Illuminate\Database\Eloquent\Model  $model
      * @return \Illuminate\Contracts\Database\Eloquent\Builder

--- a/tests/Support/Repositories/ByteSizeGuardedTagRepository.php
+++ b/tests/Support/Repositories/ByteSizeGuardedTagRepository.php
@@ -9,8 +9,8 @@ use SineMacula\Repositories\Repository;
 use Tests\Support\Models\Tag;
 
 /**
- * Fixture cacheable tag repository with a byte-size guard ceiling too small
- * for any real result to pass.
+ * Fixture cacheable tag repository with a byte-size guard ceiling too small for
+ * any real result to pass.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Support/Repositories/ShortReferenceTtlTagRepository.php
+++ b/tests/Support/Repositories/ShortReferenceTtlTagRepository.php
@@ -9,8 +9,8 @@ use SineMacula\Repositories\Repository;
 use Tests\Support\Models\Tag;
 
 /**
- * Fixture cacheable tag repository operating in whole-table reference mode
- * with a short reference-mode TTL.
+ * Fixture cacheable tag repository operating in whole-table reference mode with
+ * a short reference-mode TTL.
  *
  * @author      Ben Carey <bdmc@sinemacula.co.uk>
  * @copyright   2026 Sine Macula Limited.

--- a/tests/Unit/Concerns/CacheStoreOptionsTest.php
+++ b/tests/Unit/Concerns/CacheStoreOptionsTest.php
@@ -21,8 +21,8 @@ use SineMacula\Repositories\Concerns\CacheStoreOptions;
 final class CacheStoreOptionsTest extends TestCase
 {
     /**
-     * Test that the constructor assigns each option to its matching
-     * readonly property, unchanged.
+     * Test that the constructor assigns each option to its matching readonly
+     * property, unchanged.
      *
      * @return void
      */


### PR DESCRIPTION
## Summary

- reflow PHPDoc prose greedily to use the available 80-column width
- preserve intentional paragraph boundaries, lists, code samples, diagrams, and atomic tag lines
- apply the convention consistently across production and test code
- allow the scoped mutation gate to pass when a diff produces no mutants

## Why

Several docblocks wrapped prose before the next whole word would exceed column 80, creating inconsistent and unnecessarily narrow documentation. This standardizes the wrapping without changing runtime behavior.

Comment-only source diffs legitimately produce zero Infection mutants. The scoped gate previously applied its 90% MSI thresholds to that empty set and failed at 0%. `--ignore-msi-with-no-mutations` now handles that case while preserving both 90% thresholds whenever mutants are generated.

## Validation

- `composer validate --strict`
- `composer format`
- `qlty check`
- `composer test` — 257 tests, 548 assertions
- `composer test:mutation` — passes with zero mutants for this comment-only diff
- PHP CS Fixer dry-run — 0 fixable files
- full PHPDoc audit — 0 premature prose wraps and 0 overlong prose lines
- `git diff --check`