### PR TITLE
ci: run the full mutation suite on master pushes

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -65,10 +65,10 @@ jobs:
                 run: composer test:mutation
 
     # ==========================================================================
-    # JOB: FULL MUTATION SUITE (SCHEDULED + MANUAL)
+    # JOB: FULL MUTATION SUITE (PUSH + SCHEDULED + MANUAL)
     # ==========================================================================
     mutation-full:
-        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         continue-on-error: true
         name: Mutation Full / PHP 8.3
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The Quality Gates workflow triggers on pushes to master, but neither of its jobs had a condition matching the push event - the scoped gate runs only on `pull_request` and the full suite only on `schedule`/`workflow_dispatch`. Every merge to master therefore produced a run in which all jobs were skipped, and since the README badge reflects the most recent master run, any merge landing after the weekly cron left the badge showing "no status" until the following Monday.

This adds `push` to the full-suite job's condition, so every merge to master executes a real run and the badge stays live. The scoped, thresholded gate remains PR-only, where a diff exists for it to mutate.

## Verification

Merging this PR is itself the test: the resulting push to master should produce a Quality Gates run that executes (rather than skips) the full mutation suite, after which the README badge should report a status.