### PR TITLE
ci: run the scoped mutation gate on pushes

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -38,10 +38,10 @@ defaults:
 jobs:
 
     # ==========================================================================
-    # JOB: SCOPED MUTATION GATE (PR)
+    # JOB: SCOPED MUTATION GATE (PR + PUSH)
     # ==========================================================================
     mutation:
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name != 'schedule' }}
         name: Mutation / PHP 8.3
         runs-on: ubuntu-latest
 
@@ -65,10 +65,10 @@ jobs:
                 run: composer test:mutation
 
     # ==========================================================================
-    # JOB: FULL MUTATION SUITE (PUSH + SCHEDULED + MANUAL)
+    # JOB: FULL MUTATION SUITE (SCHEDULED + MANUAL)
     # ==========================================================================
     mutation-full:
-        if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         continue-on-error: true
         name: Mutation Full / PHP 8.3
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Aligns this repository's Quality Gates workflow with the current generation of the shared template: the scoped mutation gate now runs on every event except the weekly schedule (pull requests, master pushes, and manual dispatches), and the full mutation suite returns to schedule and manual dispatch only.

This supersedes the previous interim fix, which routed master pushes to the full suite instead. Push runs of the scoped gate resolve against an empty diff and pass in seconds, keeping every merge's run - and the README badge - live without the cost of a full suite per merge.

The base-branch fetch steps are intentionally retained because the scoped gate is diff-based and needs the `origin/master` ref on pull-request events.
