### PR TITLE
style: conform comment wrapping to coding-standards v1.17.0

### DIFF
--- a/src/Concerns/Cacheable.php
+++ b/src/Concerns/Cacheable.php
@@ -152,8 +152,8 @@ trait Cacheable
 
         // The reference-mode snapshot key is qualified with the connection
         // identity (unlike the per-query key, which folds it into the query
-        // fingerprint instead), so two connections exposing the same table
-        // name never share a whole-table snapshot.
+        // fingerprint instead), so two connections exposing the same table name
+        // never share a whole-table snapshot.
         $connection      = $model->getConnection();
         $referencePrefix = $configuration->prefix . ':' . $connection->getName() . ':' . $connection->getDatabaseName();
 

--- a/src/Concerns/ManagesCriteria.php
+++ b/src/Concerns/ManagesCriteria.php
@@ -16,10 +16,9 @@ use SineMacula\Repositories\Contracts\DeclaresRelationshipCounts;
  * transient criteria application with runtime control toggles.
  *
  * Flag precedence:
- * - $skipCriteria overrides all other flags; when true, no criteria
- *   (persistent or transient) are applied. Both $skipCriteria and
- *   $forceUseCriteria are reset after the query, and transient criteria are
- *   cleared.
+ * - $skipCriteria overrides all other flags; when true, no criteria (persistent
+ *   or transient) are applied. Both $skipCriteria and $forceUseCriteria are
+ *   reset after the query, and transient criteria are cleared.
  * - $forceUseCriteria overrides $disableCriteria for persistent criteria,
  *   allowing useCriteria()/withCriteria() to temporarily re-enable criteria
  *   even when globally disabled.

--- a/src/Concerns/QueryFingerprint.php
+++ b/src/Concerns/QueryFingerprint.php
@@ -168,11 +168,11 @@ final class QueryFingerprint
         $reflection = new \ReflectionFunction($constraint);
         $boundThis  = $reflection->getClosureThis();
 
-        // The framework combines eager-load constraints into a closure bound
-        // to the query builder itself (not application state); excluded here
-        // both because it carries no identity of its own and because the
-        // builder holds a live, unserializable database connection. A closure
-        // bound to itself would otherwise also recurse forever below.
+        // The framework combines eager-load constraints into a closure bound to
+        // the query builder itself (not application state); excluded here both
+        // because it carries no identity of its own and because the builder
+        // holds a live, unserializable database connection. A closure bound to
+        // itself would otherwise also recurse forever below.
         $identity = $boundThis === null || $boundThis === $constraint || $boundThis instanceof Builder
             ? null
             : self::normaliseCapture($boundThis);

--- a/src/Concerns/ReferenceCache.php
+++ b/src/Concerns/ReferenceCache.php
@@ -170,9 +170,9 @@ final class ReferenceCache implements CacheInvalidator
         $rows = $model->newQuery()->get();
 
         // Skip caching a table over the size guard: reference mode on an
-        // unexpectedly large table falls back to querying each read rather
-        // than holding (or memoising) a huge serialized snapshot. Any earlier
-        // memo state is dropped so no stale index can outlive the snapshot.
+        // unexpectedly large table falls back to querying each read rather than
+        // holding (or memoising) a huge serialized snapshot. Any earlier memo
+        // state is dropped so no stale index can outlive the snapshot.
         if (!$this->sizeGuard->allows($rows, $rows->count())) {
 
             $this->memo  = null;

--- a/src/Enums/CacheKeys.php
+++ b/src/Enums/CacheKeys.php
@@ -23,8 +23,8 @@ enum CacheKeys: string
     // Store a per-query cached result for a repository (table, query hash)
     case REPOSITORY_QUERY_CACHE = 'repository-query:%s:%s';
 
-    // Store the generational version that scopes a repository table's
-    // per-query keys
+    // Store the generational version that scopes a repository table's per-query
+    // keys
     case REPOSITORY_CACHE_VERSION = 'repository-cache-version:%s';
 
     /**

--- a/testing/CriteriaTestHelper.php
+++ b/testing/CriteriaTestHelper.php
@@ -24,11 +24,7 @@ use SineMacula\Repositories\Contracts\CriteriaInterface;
 final class CriteriaTestHelper
 {
     // phpcs:disable Squiz.Commenting.VariableComment -- @managed-static documents intentional shared state
-    /**
-     * @var \Illuminate\Database\Capsule\Manager|null Shared capsule instance
-     *
-     * @managed-static Memoized in-memory SQLite connection shared across calls.
-     */
+    /** @var \Illuminate\Database\Capsule\Manager|null Memoized in-memory SQLite connection shared across calls. @managed-static */
     private static ?Capsule $capsule = null;
     // phpcs:enable Squiz.Commenting.VariableComment
 

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -87,10 +87,10 @@ abstract class IntegrationTestCase extends TestCase
             'foreign_key_constraints' => true,
         ]);
 
-        // Isolate the file cache per test so parallel test runs (each mutant
-        // is a separate process during mutation testing) never collide on a
-        // shared cache directory, which otherwise makes TTL/expiry-sensitive
-        // cache assertions flap and the mutation score non-deterministic.
+        // Isolate the file cache per test so parallel test runs (each mutant is
+        // a separate process during mutation testing) never collide on a shared
+        // cache directory, which otherwise makes TTL/expiry-sensitive cache
+        // assertions flap and the mutation score non-deterministic.
         $this->fileCachePath = sys_get_temp_dir() . '/laravel-repositories-test-cache-' . getmypid() . '-' . uniqid('', true);
         $app['config']->set('cache.stores.file.path', $this->fileCachePath);
     }


### PR DESCRIPTION
## Summary

Runs the latest coding standards (v1.17.0, already pinned by renovate in `.qlty/qlty.toml` and resolved via composer) across the repo and fixes everything they surfaced. All changes are comment-only - no functional change, so this can merge without a release.

The local qlty tool sandboxes had been built from a different repo's composer.json and lacked `sinemacula/coding-standards-laravel`, so they were cleared and rebuilt before checking.

## Findings fixed

- **`SineMacula.Commenting.CommentLineLength.PrematurelyWrapped`** (6): the new deterministic wrapping rules require comment prose to fill each line greedily to 80 characters. Rewrapped the flagged blocks in `Cacheable`, `ManagesCriteria`, `QueryFingerprint`, `ReferenceCache`, `CacheKeys`, and `IntegrationTestCase`.
- **`SineMacula.Commenting.SingleLineMemberComment.Multiline`** (1): the `$capsule` member docblock in `CriteriaTestHelper` collapsed to a single line. The `@managed-static` opt-out moved inline - the static-analysis collector matches the tag anywhere in the property docblock, so the opt-out still applies (verified by the clean check).

## Verification

- `composer check` (full, uncached): no issues
- `composer format`: no changes
- `composer smells`: only the 5 pre-existing many-parameter constructor findings on the cache value objects - untouched by this change, left as-is
- `composer test`: 257 tests, 548 assertions, all passing