### PR TITLE
feat!: support Laravel 13 and drop Laravel 11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,32 +37,16 @@ defaults:
 jobs:
 
     # ==========================================================================
-    # JOB: TESTS
+    # JOB: PHP TESTS
     # ==========================================================================
-    tests:
-        name: Test / PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel.label }}
+    php:
+        name: Test / PHP ${{ matrix.php }}
         runs-on: ubuntu-latest
 
         strategy:
             fail-fast: false
             matrix:
-                include:
-                    -   php: 8.3
-                        laravel:
-                            constraint: ^12.0
-                            label: 12
-                    -   php: 8.4
-                        laravel:
-                            constraint: ^12.0
-                            label: 12
-                    -   php: 8.5
-                        laravel:
-                            constraint: ^12.0
-                            label: 12
-                    -   php: 8.3
-                        laravel:
-                            constraint: ^13.0
-                            label: 13
+                php: [ 8.3, 8.4, 8.5 ]
 
         steps:
             -   name: Checkout
@@ -74,6 +58,36 @@ jobs:
                 uses: sinemacula/.github/.github/actions/setup-php@v1.1.1
                 with:
                     php-version: ${{ matrix.php }}
+
+            -   name: PHPUnit
+                run: composer test:coverage
+
+    # ==========================================================================
+    # JOB: LARAVEL TESTS
+    # ==========================================================================
+    laravel:
+        name: Test / Laravel ${{ matrix.laravel.label }}
+        runs-on: ubuntu-latest
+
+        strategy:
+            fail-fast: false
+            matrix:
+                laravel:
+                    -   constraint: ^12.0
+                        label: 12
+                    -   constraint: ^13.0
+                        label: 13
+
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v5
+                with:
+                    persist-credentials: false
+
+            -   name: Setup PHP
+                uses: sinemacula/.github/.github/actions/setup-php@v1.1.1
+                with:
+                    php-version: 8.3
 
             -   name: Pin Laravel version
                 env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,13 @@ jobs:
             -   name: PHPUnit
                 run: composer test:coverage
 
+            -   name: Publish code coverage
+                if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.php == '8.3' }}
+                uses: qltysh/qlty-action/coverage@v2
+                with:
+                    oidc: true
+                    files: clover.xml
+
     # ==========================================================================
     # JOB: LARAVEL TESTS
     # ==========================================================================
@@ -95,11 +102,4 @@ jobs:
                 run: composer update --with="laravel/framework:${LARAVEL_CONSTRAINT}" --prefer-dist --no-interaction --no-progress
 
             -   name: PHPUnit
-                run: composer test:coverage
-
-            -   name: Publish code coverage
-                if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.laravel.label == '13' }}
-                uses: qltysh/qlty-action/coverage@v2
-                with:
-                    oidc: true
-                    files: clover.xml
+                run: composer test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,10 @@ jobs:
                         laravel:
                             constraint: ^12.0
                             label: 12
+                    -   php: 8.5
+                        laravel:
+                            constraint: ^12.0
+                            label: 12
                     -   php: 8.3
                         laravel:
                             constraint: ^13.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,13 +40,29 @@ jobs:
     # JOB: TESTS
     # ==========================================================================
     tests:
-        name: Test / PHP ${{ matrix.php }}
+        name: Test / PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel.label }}
         runs-on: ubuntu-latest
 
         strategy:
             fail-fast: false
             matrix:
-                php: [ 8.3, 8.4 ]
+                include:
+                    -   php: 8.3
+                        laravel:
+                            constraint: ^12.0
+                            label: 12
+                    -   php: 8.3
+                        laravel:
+                            constraint: ^13.0
+                            label: 13
+                    -   php: 8.4
+                        laravel:
+                            constraint: ^12.0
+                            label: 12
+                    -   php: 8.4
+                        laravel:
+                            constraint: ^13.0
+                            label: 13
 
         steps:
             -   name: Checkout
@@ -59,11 +75,16 @@ jobs:
                 with:
                     php-version: ${{ matrix.php }}
 
+            -   name: Pin Laravel version
+                env:
+                    LARAVEL_CONSTRAINT: ${{ matrix.laravel.constraint }}
+                run: composer update --with="laravel/framework:${LARAVEL_CONSTRAINT}" --prefer-dist --no-interaction --no-progress
+
             -   name: PHPUnit
                 run: composer test:coverage
 
             -   name: Publish code coverage
-                if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.php == '8.3' }}
+                if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.php == '8.3' && matrix.laravel.label == '13' }}
                 uses: qltysh/qlty-action/coverage@v2
                 with:
                     oidc: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,15 +51,11 @@ jobs:
                         laravel:
                             constraint: ^12.0
                             label: 12
-                    -   php: 8.3
-                        laravel:
-                            constraint: ^13.0
-                            label: 13
                     -   php: 8.4
                         laravel:
                             constraint: ^12.0
                             label: 12
-                    -   php: 8.4
+                    -   php: 8.3
                         laravel:
                             constraint: ^13.0
                             label: 13
@@ -84,7 +80,7 @@ jobs:
                 run: composer test:coverage
 
             -   name: Publish code coverage
-                if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.php == '8.3' && matrix.laravel.label == '13' }}
+                if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.laravel.label == '13' }}
                 uses: qltysh/qlty-action/coverage@v2
                 with:
                     oidc: true

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ required to move from 1.x to 2.x.
 ## Requirements
 
 - PHP ^8.3
-- Laravel 11+
+- Laravel 12+
 
 ## Testing
 

--- a/composer.json
+++ b/composer.json
@@ -16,16 +16,16 @@
     ],
     "require": {
         "php": "^8.3",
-        "illuminate/cache": "^11.0 || ^12.0",
-        "illuminate/database": "^11.0 || ^12.0",
-        "illuminate/support": "^11.0 || ^12.0"
+        "illuminate/cache": "^11.0 || ^12.0 || ^13.0",
+        "illuminate/database": "^11.0 || ^12.0 || ^13.0",
+        "illuminate/support": "^11.0 || ^12.0 || ^13.0"
     },
     "require-dev": {
         "brianium/paratest": "^7.20",
         "friendsofphp/php-cs-fixer": "^3.94",
         "infection/infection": "^0.33.2",
         "mockery/mockery": "^1.6",
-        "orchestra/testbench": "^9.0 || ^10.0",
+        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpdoc-parser": "^2.3",
         "phpstan/phpstan": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -16,16 +16,16 @@
     ],
     "require": {
         "php": "^8.3",
-        "illuminate/cache": "^11.0 || ^12.0 || ^13.0",
-        "illuminate/database": "^11.0 || ^12.0 || ^13.0",
-        "illuminate/support": "^11.0 || ^12.0 || ^13.0"
+        "illuminate/cache": "^12.0 || ^13.0",
+        "illuminate/database": "^12.0 || ^13.0",
+        "illuminate/support": "^12.0 || ^13.0"
     },
     "require-dev": {
         "brianium/paratest": "^7.20",
         "friendsofphp/php-cs-fixer": "^3.94",
         "infection/infection": "^0.33.2",
         "mockery/mockery": "^1.6",
-        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
+        "orchestra/testbench": "^10.0 || ^11.0",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpdoc-parser": "^2.3",
         "phpstan/phpstan": "^2.1",


### PR DESCRIPTION
Widens the illuminate constraints to Laravel 12/13 and adds the canonical split CI matrix (a PHP compatibility job on 8.3/8.4/8.5 with unpinned dependencies, and a Laravel compatibility job pinning 12 and 13 on PHP 8.3; the pinned legs validated locally with the exact CI pin command - 257 tests per leg).

Laravel 11 support is dropped rather than carried: 11 is past its security-fix window, every 11.x release has permanently unpatched advisories, and composer's `audit.block-insecure` default means CI could never resolve (let alone test) an 11 leg - keeping the constraint would advertise a major the matrix cannot exercise.

**Breaking**: consumers on Laravel 11 must upgrade to 12+ before taking this release (ships as v3.0.0).

Also aligns the test matrix with the org standard: a PHP compatibility job tests PHP 8.3/8.4/8.5 with dependencies resolved unpinned (so the newest supported Laravel is used), and a Laravel compatibility job tests Laravel 12 and 13 pinned on PHP 8.3 (coverage is published from the PHP job's 8.3 leg); mutation flags were already compliant.

