### PR TITLE
chore: apply the current coding standards

### DIFF
--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -39,7 +39,8 @@ exclude_patterns = [
     "**/templates/**",
     "**/testdata/**",
     "**/vendor/**",
-    ".qlty/configs/**"
+    ".qlty/configs/**",
+    ".sinemacula/**"
 ]
 
 test_patterns = [

--- a/src/Concerns/CacheConfiguration.php
+++ b/src/Concerns/CacheConfiguration.php
@@ -20,7 +20,7 @@ use Illuminate\Support\Facades\Config;
  *
  * @internal
  */
-final class CacheConfiguration
+final readonly class CacheConfiguration
 {
     /**
      * Create a new cache configuration instance.
@@ -35,19 +35,19 @@ final class CacheConfiguration
     private function __construct(
 
         /** The resolved Laravel cache store name. */
-        public readonly string $storeName,
+        public string $storeName,
 
         /** The resolved per-query cache key prefix. */
-        public readonly string $prefix,
+        public string $prefix,
 
         /** Whether the repository operates in whole-table reference mode. */
-        public readonly bool $referenceMode,
+        public bool $referenceMode,
 
         /** The resolved reference-mode cache lifetime, in seconds. */
-        public readonly int $referenceTtl,
+        public int $referenceTtl,
 
         /** The resolved per-query cache store options. */
-        public readonly CacheStoreOptions $storeOptions,
+        public CacheStoreOptions $storeOptions,
     ) {}
 
     /**

--- a/src/Concerns/QueryFingerprint.php
+++ b/src/Concerns/QueryFingerprint.php
@@ -209,7 +209,7 @@ final class QueryFingerprint
 
         try {
             $base = rtrim(base_path(), \DIRECTORY_SEPARATOR);
-        } catch (\Throwable) {
+        } catch (\Throwable) { // @phpstan-ignore catch.neverThrown
             // No bound Laravel application (or the helper is unavailable);
             // fingerprint the path unchanged.
             return $path;

--- a/tests/Integration/Concerns/CacheableTest.php
+++ b/tests/Integration/Concerns/CacheableTest.php
@@ -680,6 +680,8 @@ final class CacheableTest extends IntegrationTestCase
      * whole-table query rather than the per-query cache.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testReferenceModeServesMixedReadsFromASingleQuery(): void
     {

--- a/tests/Integration/Concerns/QueryFingerprintTest.php
+++ b/tests/Integration/Concerns/QueryFingerprintTest.php
@@ -349,6 +349,8 @@ final class QueryFingerprintTest extends IntegrationTestCase
      * @param  \Illuminate\Container\Container  $second
      * @param  bool  $expectSameFingerprint
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\UnfingerprintableQueryException
      */
     #[DataProvider('definitionPathNormalisationProvider')]
     public function testDefinitionPathIsNormalisedRelativeToTheApplicationBasePath(Container $first, Container $second, bool $expectSameFingerprint): void
@@ -380,6 +382,8 @@ final class QueryFingerprintTest extends IntegrationTestCase
      * collide on one cache key.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\UnfingerprintableQueryException
      */
     public function testClosureArgumentsCannotBeFingerprinted(): void
     {

--- a/tests/Integration/CriteriaFlagStateTest.php
+++ b/tests/Integration/CriteriaFlagStateTest.php
@@ -51,6 +51,8 @@ final class CriteriaFlagStateTest extends IntegrationTestCase
      * Persistent criteria applied. No transient criteria present.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testState01EnabledNoSkipNoForceNoTransient(): void
     {
@@ -68,6 +70,8 @@ final class CriteriaFlagStateTest extends IntegrationTestCase
      * Both persistent and transient criteria applied.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testState02EnabledNoSkipNoForceWithTransient(): void
     {
@@ -92,6 +96,8 @@ final class CriteriaFlagStateTest extends IntegrationTestCase
      * are not disabled.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testState03EnabledNoSkipForceNoTransient(): void
     {
@@ -111,6 +117,8 @@ final class CriteriaFlagStateTest extends IntegrationTestCase
      * after calling withCriteria().
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testState04EnabledNoSkipForceWithTransient(): void
     {
@@ -129,6 +137,8 @@ final class CriteriaFlagStateTest extends IntegrationTestCase
      * Skip overrides: no criteria applied despite persistent being present.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testState05EnabledSkipNoForceNoTransient(): void
     {
@@ -147,6 +157,8 @@ final class CriteriaFlagStateTest extends IntegrationTestCase
      * Skip overrides: both persistent and transient are skipped.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testState06EnabledSkipNoForceWithTransient(): void
     {
@@ -170,6 +182,8 @@ final class CriteriaFlagStateTest extends IntegrationTestCase
      * Skip overrides force: no criteria applied.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testState07EnabledSkipForceNoTransient(): void
     {
@@ -189,6 +203,8 @@ final class CriteriaFlagStateTest extends IntegrationTestCase
      * Skip overrides everything: all criteria skipped.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testState08EnabledSkipForceWithTransient(): void
     {
@@ -208,6 +224,8 @@ final class CriteriaFlagStateTest extends IntegrationTestCase
      * Persistent criteria NOT applied (disabled). No transient present.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testState09DisabledNoSkipNoForceNoTransient(): void
     {
@@ -227,6 +245,8 @@ final class CriteriaFlagStateTest extends IntegrationTestCase
      * Persistent NOT applied, but transient IS applied.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testState10DisabledNoSkipNoForceWithTransientTransientStillApplied(): void
     {
@@ -251,6 +271,8 @@ final class CriteriaFlagStateTest extends IntegrationTestCase
      * $forceUseCriteria overrides $disableCriteria for persistent criteria.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testState11DisabledNoSkipForceNoTransientForceOverridesDisable(): void
     {
@@ -271,6 +293,8 @@ final class CriteriaFlagStateTest extends IntegrationTestCase
      * skipped. Both criteria applied.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testState12DisabledNoSkipForceWithTransientBothApplied(): void
     {
@@ -290,6 +314,8 @@ final class CriteriaFlagStateTest extends IntegrationTestCase
      * Skip overrides: no criteria applied. Disable is redundant.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testState13DisabledSkipNoForceNoTransient(): void
     {
@@ -309,6 +335,8 @@ final class CriteriaFlagStateTest extends IntegrationTestCase
      * Skip overrides disable and suppresses transient criteria.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testState14DisabledSkipNoForceWithTransientSkipSuppressesAll(): void
     {
@@ -333,6 +361,8 @@ final class CriteriaFlagStateTest extends IntegrationTestCase
      * Skip overrides both disable and force: no criteria applied.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testState15DisabledSkipForceNoTransientSkipOverridesBoth(): void
     {
@@ -353,6 +383,8 @@ final class CriteriaFlagStateTest extends IntegrationTestCase
      * All flags active. Skip wins: no criteria applied.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testState16AllFlagsActiveSkipWins(): void
     {
@@ -371,6 +403,8 @@ final class CriteriaFlagStateTest extends IntegrationTestCase
      * Verify the skip criteria flag resets to false after a query executes.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testSkipCriteriaFlagResetsAfterQuery(): void
     {
@@ -392,6 +426,8 @@ final class CriteriaFlagStateTest extends IntegrationTestCase
      * executes.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testForceUseCriteriaFlagResetsAfterQuery(): void
     {
@@ -413,6 +449,8 @@ final class CriteriaFlagStateTest extends IntegrationTestCase
      * Verify the disable criteria flag persists across queries.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testDisableCriteriaPersistsAfterQuery(): void
     {
@@ -432,6 +470,8 @@ final class CriteriaFlagStateTest extends IntegrationTestCase
      * Verify transient criteria are cleared after each query.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testTransientCriteriaClearedAfterQuery(): void
     {

--- a/tests/Integration/PerQueryCacheTest.php
+++ b/tests/Integration/PerQueryCacheTest.php
@@ -139,6 +139,8 @@ final class PerQueryCacheTest extends IntegrationTestCase
      * Test that reference mode loads the whole table once for mixed reads.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testReferenceModeLoadsTableOnceForMixedReads(): void
     {
@@ -223,6 +225,8 @@ final class PerQueryCacheTest extends IntegrationTestCase
      * mode.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testAllServesAndCachesInPerQueryMode(): void
     {

--- a/tests/Integration/RepositoryCriteriaIntegrationTest.php
+++ b/tests/Integration/RepositoryCriteriaIntegrationTest.php
@@ -31,6 +31,8 @@ final class RepositoryCriteriaIntegrationTest extends IntegrationTestCase
      * Verify persistent criteria behavior across enable, disable, and use flow.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testPersistentCriteriaBehaviorAcrossEnableDisableAndUseFlow(): void
     {
@@ -58,6 +60,8 @@ final class RepositoryCriteriaIntegrationTest extends IntegrationTestCase
      * Verify skipCriteria bypasses criteria for one query and resets flags.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testSkipCriteriaBypassesCriteriaForSingleQueryAndResetsFlags(): void
     {

--- a/tests/Integration/RepositoryIntegrationTest.php
+++ b/tests/Integration/RepositoryIntegrationTest.php
@@ -35,6 +35,8 @@ final class RepositoryIntegrationTest extends IntegrationTestCase
      * Verify constructor initialization and boot behavior.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testConstructorInitializesStateAndBootsRepository(): void
     {
@@ -51,6 +53,8 @@ final class RepositoryIntegrationTest extends IntegrationTestCase
      * Verify the base boot() method executes when a child does not override it.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testBaseBootMethodIsExecutedOnConstruction(): void
     {
@@ -65,6 +69,8 @@ final class RepositoryIntegrationTest extends IntegrationTestCase
      * Verify getModel restores a valid model when state is corrupted.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testGetModelRestoresModelWhenInternalReferenceIsInvalid(): void
     {
@@ -80,6 +86,8 @@ final class RepositoryIntegrationTest extends IntegrationTestCase
      * Verify query() and newQuery() return builders and reset transient state.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testQueryAndNewQueryReturnBuildersAndResetTransientState(): void
     {
@@ -102,6 +110,8 @@ final class RepositoryIntegrationTest extends IntegrationTestCase
      * Verify applyCriteria restores the model when its internal state is null.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testQueryRestoresModelWhenInternalModelIsNull(): void
     {
@@ -115,6 +125,8 @@ final class RepositoryIntegrationTest extends IntegrationTestCase
      * Verify __call forwards to the query builder and resets transient state.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testCallForwardsMethodCallsToQueryBuilder(): void
     {
@@ -153,6 +165,8 @@ final class RepositoryIntegrationTest extends IntegrationTestCase
      * Verify query recovers from an invalid model reference and applies scopes.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testQueryRecoversFromInvalidModelAndAppliesScopes(): void
     {
@@ -174,6 +188,8 @@ final class RepositoryIntegrationTest extends IntegrationTestCase
      * Verify resetAndReturn clears transient state and preserves result value.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testResetAndReturnClearsTransientState(): void
     {
@@ -196,6 +212,8 @@ final class RepositoryIntegrationTest extends IntegrationTestCase
      * Verify resetModel() restores a fresh model instance from the container.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testResetModelRestoresFreshModelInstance(): void
     {
@@ -312,6 +330,8 @@ final class RepositoryIntegrationTest extends IntegrationTestCase
      * identically to a directly forwarded get() call.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testAllDelegatesToTheGetPipeline(): void
     {

--- a/tests/Integration/SupplementaryCapabilityTest.php
+++ b/tests/Integration/SupplementaryCapabilityTest.php
@@ -35,6 +35,8 @@ final class SupplementaryCapabilityTest extends IntegrationTestCase
      * Verify that eager-loading declarations are collected from criteria.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testEagerLoadingDeclarationsAreCollected(): void
     {
@@ -54,6 +56,8 @@ final class SupplementaryCapabilityTest extends IntegrationTestCase
      * Verify that field selection declarations are collected from criteria.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testFieldSelectionDeclarationsAreCollected(): void
     {
@@ -69,6 +73,8 @@ final class SupplementaryCapabilityTest extends IntegrationTestCase
      * Verify that relationship count declarations are collected from criteria.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testRelationshipCountDeclarationsAreCollected(): void
     {
@@ -87,6 +93,8 @@ final class SupplementaryCapabilityTest extends IntegrationTestCase
      * Verify that metadata is collected from criteria.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testMetadataIsCollectedFromCriteria(): void
     {
@@ -106,6 +114,8 @@ final class SupplementaryCapabilityTest extends IntegrationTestCase
      * declarations.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testCriteriaWithoutSupplementaryContractsContributeNothing(): void
     {
@@ -124,6 +134,8 @@ final class SupplementaryCapabilityTest extends IntegrationTestCase
      * Verify that declarations from multiple criteria are merged.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testDeclarationsFromMultipleCriteriaAreMerged(): void
     {
@@ -146,6 +158,8 @@ final class SupplementaryCapabilityTest extends IntegrationTestCase
      * Verify that collected declarations are cleared on the next query.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testCollectedDeclarationsAreClearedOnNextQuery(): void
     {
@@ -169,6 +183,8 @@ final class SupplementaryCapabilityTest extends IntegrationTestCase
      * Verify that skipped criteria do not contribute declarations.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testSkippedCriteriaDoNotContributeDeclarations(): void
     {
@@ -187,6 +203,8 @@ final class SupplementaryCapabilityTest extends IntegrationTestCase
      * but transient criteria still do.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testDisabledPersistentDoNotContributeButTransientDo(): void
     {
@@ -214,6 +232,8 @@ final class SupplementaryCapabilityTest extends IntegrationTestCase
      * and the ordering produces the correct result.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testTransientCriteriaApplyBeforePersistentCriteria(): void
     {
@@ -243,6 +263,8 @@ final class SupplementaryCapabilityTest extends IntegrationTestCase
      * without modification.
      *
      * @return void
+     *
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testExistingCriteriaWorkWithoutModification(): void
     {

--- a/tests/Unit/RepositoryTest.php
+++ b/tests/Unit/RepositoryTest.php
@@ -32,6 +32,7 @@ final class RepositoryTest extends TestCase
      * @return void
      *
      * @throws \PHPUnit\Framework\MockObject\Exception
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testMakeModelThrowsWhenResolvedClassIsNotEloquentModel(): void
     {
@@ -56,6 +57,7 @@ final class RepositoryTest extends TestCase
      * @return void
      *
      * @throws \PHPUnit\Framework\MockObject\Exception
+     * @throws \SineMacula\Repositories\Exceptions\RepositoryException
      */
     public function testConstructorBootsConcernsWithDedicatedBootHooks(): void
     {


### PR DESCRIPTION
The standards package is distributed automatically, but Qlty Cloud only analyses the diff of the update PR - so the newly shipped rules were never run against the existing code. This runs the full ruleset (`qlty check --all`, `qlty fmt`, `qlty smells`) over the whole repository and resolves what it reported.

Eighty-six findings, in four groups.

## Analysis was reading the local agent state directory

Twenty-six of the eighty-six were markdownlint findings inside `.sinemacula/`, which holds local agent state rather than repository content. Every other package in the group already carries `".sinemacula/**"` in its `exclude_patterns`; this one did not. Added it, which is a config gap rather than a code fix - these never reached Qlty Cloud, since a fresh clone has no such directory.

## `missingType.checkedException` in the tests (fifty sites)

`RepositoryException` and `UnfingerprintableQueryException` are both checked, so every test method that reaches them has to declare it. Added `@throws` accordingly.

I converged this by re-running the analyser after each pass rather than tagging the reported list in one go - declaring a checked exception on a helper makes every caller a throw site in its own right, so a single pass can leave the gate red. Here it settled after one round with no cascade.

## `sineMacula.readonlyClass` on `CacheConfiguration`

Every property is readonly, so the class qualifies. Promoted the modifier to the class and dropped the redundant per-property `readonly`.

## `catch.neverThrown` in `QueryFingerprint::normaliseDefinitionPath()`

Not a dead catch. It guards `base_path()` against there being no bound application - the failure arrives as an unchecked throwable, which the shared config deliberately does not track, so the analyser concludes nothing in the try block throws. Kept the catch and marked it with `@phpstan-ignore catch.neverThrown`, matching how the same false positive is handled elsewhere in the org. The behaviour it guards is covered by `testDefinitionPathIsNormalisedRelativeToTheApplicationBasePath`.

## Left alone

`qlty smells` reports five "function with many parameters" findings on the value-object constructors in `src/Concerns/` (`CacheConfiguration`, `CacheStatus`, `CacheStore`, `CacheStoreOptions`, `ReferenceCache`). I confirmed these are byte-for-byte identical before and after this branch - they are the deliberate promoted-readonly-property shape, and collapsing them into parameter objects is a design decision rather than a standards fix, so I have not folded it in here.

## Verification

- `qlty check --all --no-cache` - no issues
- `qlty fmt --all` - no changes
- `qlty smells --all` - unchanged from master (five pre-existing, listed above)
- `composer test` - 257 passed, 548 assertions (unchanged from before)

The test tree changes are docblock-only; no test behaviour changed.