### PR TITLE
ci(qlty): pin the static analysis tool environment

### DIFF
--- a/.qlty/configs/composer.json
+++ b/.qlty/configs/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.2",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpdoc-parser": "^2.3",
         "phpstan/phpstan": "^2.1",
@@ -7,7 +8,8 @@
         "phpstan/phpstan-mockery": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "sinemacula/coding-standards-laravel": "^1.5.0"
+        "sinemacula/coding-standards-laravel": "^1.5.0",
+        "slevomat/coding-standard": "^8.28"
     },
     "conflict": {
         "symfony/clock": ">=8.0",
@@ -28,7 +30,8 @@
     },
     "config": {
         "allow-plugins": {
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
     "scripts": {}

--- a/.qlty/configs/composer.json
+++ b/.qlty/configs/composer.json
@@ -1,0 +1,35 @@
+{
+    "require": {
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpdoc-parser": "^2.3",
+        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-mockery": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0",
+        "sinemacula/coding-standards-laravel": "^1.5.0"
+    },
+    "conflict": {
+        "symfony/clock": ">=8.0",
+        "symfony/console": ">=8.0",
+        "symfony/error-handler": ">=8.0",
+        "symfony/event-dispatcher": ">=8.0",
+        "symfony/filesystem": ">=8.0",
+        "symfony/finder": ">=8.0",
+        "symfony/http-foundation": ">=8.0",
+        "symfony/http-kernel": ">=8.0",
+        "symfony/mime": ">=8.0",
+        "symfony/options-resolver": ">=8.0",
+        "symfony/process": ">=8.0",
+        "symfony/stopwatch": ">=8.0",
+        "symfony/string": ">=8.0",
+        "symfony/translation": ">=8.0",
+        "symfony/var-dumper": ">=8.0"
+    },
+    "config": {
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
+    },
+    "scripts": {}
+}

--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -129,10 +129,14 @@ name = "yamllint"
 [[plugin]]
 name = "phpstan"
 version = "2.1.46"
+package_file = ".qlty/configs/composer.json"
+package_filters = ["phpstan", "larastan", "sinemacula"]
 
-# phpstan needs the project's vendor tree to resolve types, so install it into
-# the sandbox before linting. The scoped `--ignore-platform-req='ext-*'` keeps
-# qlty's PHP 8.3 runner from pulling a PHP 8.4 dependency set; a blanket
-# `--ignore-platform-reqs` would break the bootstrap.
+# phpstan resolves framework symbols by autoloading the package's own
+# dependencies, which a bare checkout does not have, so install them first.
+# COMPOSER_VENDOR_DIR is pinned to the repository's vendor directory because
+# the plugin environment points it at the shared phpstan tool sandbox, where an
+# install would replace the pinned analysis stack. Only extension requirements
+# are ignored so the PHP version constraint still applies.
 [plugins.definitions.phpstan.drivers.lint]
-prepare_script = "~/.qlty/cache/tools/composer/generic-42cc848a9f5e/composer.phar install --no-scripts --ignore-platform-req='ext-*'"
+prepare_script = "COMPOSER_VENDOR_DIR=vendor ~/.qlty/cache/tools/composer/generic-42cc848a9f5e/composer.phar install --no-scripts --ignore-platform-req='ext-*'"

--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -87,7 +87,7 @@ name = "osv-scanner"
 name = "php-codesniffer"
 version = "4.0.1"
 mode = "comment"
-package_file = "composer.json"
+package_file = ".qlty/configs/composer.json"
 package_filters = ["slevomat", "dealerdirect", "sinemacula"]
 
 # phpcs 4.x exits 3 on findings; without this qlty treats that as a hard error
@@ -102,7 +102,7 @@ name = "php-cs-fixer"
 # syntax), which qlty's PHP 8.3 runner cannot parse. Bump once the runner ships
 # PHP 8.4.
 version = "3.89.0"
-package_file = "composer.json"
+package_file = ".qlty/configs/composer.json"
 package_filters = ["sinemacula"]
 
 [[plugin]]


### PR DESCRIPTION
## Problem

The phpstan prepare script ran `composer install` with the plugin environment's
`COMPOSER_VENDOR_DIR`, which points at the shared phpstan tool sandbox under
`~/.qlty/cache/tools`. The package's own dependencies were installed over the
tool environment, pruning anything the package does not itself require and
leaving whichever repository ran last in control of the analysis stack. That
sandbox directory is keyed by the tool version alone, so every repository
pinning the same phpstan version shares one install.

## Fix

- Declare the analysis stack in `.qlty/configs/composer.json` and point the
  phpstan plugin at it, matching how `php-codesniffer` and `php-cs-fixer` in
  this file already use a package file.
- Pin `COMPOSER_VENDOR_DIR` to the repository's own vendor directory, so the
  package's dependencies land where the analysis can autoload them instead of
  overwriting the tool sandbox.
- Cap symfony below 8.0 in the package file: the sandbox install ignores
  platform requirements, and symfony 8 ships PHP 8.4-only syntax that the 8.3
  runner cannot parse.
- Scope the platform ignore to extensions so the PHP version constraint still
  applies, replacing the blanket ignore where one was used.

## Verification

Run with an isolated tool cache, so a concurrent run in another repository
could not swap the environment underneath it:

- phpstan: Success, 77 targets, 0 issues
- sandbox: 47 packages, no `laravel/framework`, no symfony 8.x (this package
  declares no larastan, so none is installed, matching current behaviour)
- package dependencies installed into the repository's own `vendor/`
