### PR TITLE
ci: resolve the mutation diff base without credentials

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -52,9 +52,6 @@ jobs:
                     persist-credentials: false
                     fetch-depth: 0
 
-            -   name: Fetch base branch for the diff
-                run: git fetch --no-tags origin master
-
             -   name: Setup PHP
                 uses: sinemacula/.github/.github/actions/setup-php@v1.1.1
                 with:


### PR DESCRIPTION
## Problem

The scoped mutation gate runs `infection --git-diff-base=origin/master`, so the job needs `refs/remotes/origin/master` present locally.

`actions/checkout` runs with `persist-credentials: false`, which strips the `http.extraheader` auth config once the checkout finishes. The separate `Fetch base branch for the diff` step therefore ran unauthenticated, and only succeeded because this repository is public.

## Fix

Drop the redundant fetch step. `fetch-depth: 0` already makes checkout fetch `+refs/heads/*:refs/remotes/origin/*` (see `getRefSpecForAllHistory` in `actions/checkout`) while it still holds credentials, so `origin/master` is in place before the gate runs. Nothing else in the job relied on the extra fetch.

The security posture is unchanged - credentials are still not persisted into the working tree.

Part of a sweep applying the same fix across every repository carrying this workflow block.